### PR TITLE
Fix deprecation warning about usage of bare variables.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 
 - name: Install the kerberos packages 
   yum: name={{ item }} state=present
-  with_items: kerberos_client_redhat_pkg
+  with_items: "{{ kerberos_client_redhat_pkg }}"
   when: ansible_os_family == "RedHat"
 
 - name: Install the kerberos packages 
   apt: name={{ item }} state=present
-  with_items: kerberos_client_ubuntu_pkg
+  with_items: "{{ kerberos_client_ubuntu_pkg }}"
   when: ansible_os_family == "Debian"
 
 - name: Copy the client configuration file 


### PR DESCRIPTION
With Ansible >= 2.0 the bare variables are deprecated.
See further details here under `Deprecated` section here:
https://docs.ansible.com/ansible/porting_guide_2.0.html
